### PR TITLE
Remove double3 in SHMEMSPACE; support Cray-SHMEM

### DIFF
--- a/modules/FindSHMEM.cmake
+++ b/modules/FindSHMEM.cmake
@@ -1,5 +1,5 @@
-
-find_library(shlib_found oshmem PATHS ${SHMEM_ROOT} SUFFIXES lib lib64 NO_DEFAULT_PATHS)
+# libsma.{so/a} are for Cray-SHMEM and Cray-OpenSHMEMX
+find_library(shlib_found NAMES oshmem sma PATHS ${SHMEM_ROOT} SUFFIXES lib lib64 NO_DEFAULT_PATHS)
 find_path(shhdr_found shmem.h PATHS ${SHMEM_ROOT}/include NO_DEFAULT_PATHS)
 
 find_package_handle_standard_args(SHMEMSPACE DEFAULT_MSG shlib_found shhdr_found)

--- a/src/SHMEMSPACE/Kokkos_SHMEMSpace_ViewMapping.hpp
+++ b/src/SHMEMSPACE/Kokkos_SHMEMSpace_ViewMapping.hpp
@@ -332,7 +332,7 @@ typename std::enable_if<std::is_same<T,unsigned long long>::value>::type * = nul
 
 // Aggregrate types
 
-
+#if 0  // double3 is defined in CUDA but not available on host
 KOKKOS_DEFAULTED_FUNCTION
 void shmem_type_p(double3 *ptr, const double3 &val, const int pe) {
 #ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
@@ -350,6 +350,7 @@ double3 shmem_type_g(double3 *ptr, const int pe) {
   return double3();
 #endif
 }
+#endif  // End of "#if 0"
 
 template <class T> 
 struct SHMEMDataElement {


### PR DESCRIPTION
The cgsolve example test passed on NERSC Cori with modules intel/19.0.3.199, cray-mpich/7.7.10, and cray-shmem/7.7.10