### PR TITLE
Fix googletest branch

### DIFF
--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -3,7 +3,7 @@ include(CTest)
 include(FetchContent)
 FetchContent_Declare(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           main
 )
 FetchContent_GetProperties(googletest)
 if(NOT googletest_POPULATED)


### PR DESCRIPTION
The `master` branch has been replaced by the `main` branch