### PR TITLE
Add -lnvidia-ml to examples. This is required for NVSHMEM >=2.5

### DIFF
--- a/examples/benchmarks/misslatency/CMakeLists.txt
+++ b/examples/benchmarks/misslatency/CMakeLists.txt
@@ -1,2 +1,7 @@
 add_executable(misslatency misslatency.cpp)
+
+if (Kokkos_ENABLE_NVSHMEMSPACE)
+  target_link_libraries(misslatency PRIVATE "-lnvidia-ml")
+endif()
+
 target_link_libraries(misslatency PRIVATE Kokkos::kokkosremote)

--- a/examples/benchmarks/poissonaccess/CMakeLists.txt
+++ b/examples/benchmarks/poissonaccess/CMakeLists.txt
@@ -1,2 +1,7 @@
 add_executable(poissonaccess poissonaccess.cpp)
+
+if (Kokkos_ENABLE_NVSHMEMSPACE)
+  target_link_libraries(poissonaccess PRIVATE "-lnvidia-ml")
+endif()
+
 target_link_libraries(poissonaccess PRIVATE Kokkos::kokkosremote)

--- a/examples/benchmarks/randomaccess/CMakeLists.txt
+++ b/examples/benchmarks/randomaccess/CMakeLists.txt
@@ -1,2 +1,7 @@
 add_executable(randomaccess randomaccess.cpp)
+
+if (Kokkos_ENABLE_NVSHMEMSPACE)
+  target_link_libraries(randomaccess PRIVATE "-lnvidia-ml")
+endif()
+
 target_link_libraries(randomaccess PRIVATE Kokkos::kokkosremote)

--- a/examples/cgsolve/parallel/CMakeLists.txt
+++ b/examples/cgsolve/parallel/CMakeLists.txt
@@ -1,4 +1,9 @@
 add_executable(cgsolve cgsolve.cpp)
+
+if (Kokkos_ENABLE_NVSHMEMSPACE)
+  target_link_libraries(cgsolve PRIVATE "-lnvidia-ml")
+endif()
+
 target_link_libraries(cgsolve PRIVATE Kokkos::kokkosremote)
 target_include_directories(cgsolve PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_definitions(cgsolve PRIVATE KOKKOS_ENABLE_NVSHMEM_PTR)

--- a/examples/matvec/multi-node/CMakeLists.txt
+++ b/examples/matvec/multi-node/CMakeLists.txt
@@ -1,4 +1,9 @@
 add_executable(matvec_multi matvec.cpp)
+
+if (Kokkos_ENABLE_NVSHMEMSPACE)
+  target_link_libraries(matvec_multi PRIVATE "-lnvidia-ml")
+endif()
+
 target_link_libraries(matvec_multi PRIVATE Kokkos::kokkosremote)
 target_include_directories(matvec_multi PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/examples/matvec/single-node/CMakeLists.txt
+++ b/examples/matvec/single-node/CMakeLists.txt
@@ -1,4 +1,10 @@
 add_executable(matvec_single matvec.cpp)
+
+if (Kokkos_ENABLE_NVSHMEMSPACE)
+  target_link_libraries(matvec_single PRIVATE "-lnvidia-ml")
+endif()
+
+
 target_link_libraries(matvec_single PRIVATE Kokkos::kokkosremote)
 target_include_directories(matvec_single PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -22,5 +22,10 @@ else()
 endif()
 
 add_executable(${NAME} ${TEST_SRCS})
+
+if (Kokkos_ENABLE_NVSHMEMSPACE)
+  target_link_libraries(${NAME} PRIVATE "-lnvidia-ml")
+endif()
+
 target_link_libraries(${NAME} PRIVATE Kokkos::kokkosremote)
 target_link_libraries(${NAME} PRIVATE gtest_main)


### PR DESCRIPTION
NVSHMEM >=2.5 has a dependency on "-lnvidia-ml". This PR adds the dependency to all executables. 