### PR TITLE
Allow propagation of MPI_Window to subviews

### DIFF
--- a/src/core/Kokkos_RemoteSpaces_ViewMapping.hpp
+++ b/src/core/Kokkos_RemoteSpaces_ViewMapping.hpp
@@ -302,22 +302,23 @@ class ViewMapping<
     dst.m_offset_remote_dim = extents.domain_offset(0);
     dst.dim0_is_pe          = R0;
 
-    #ifdef KOKKOS_ENABLE_MPISPACE
+#ifdef KOKKOS_ENABLE_MPISPACE
     // Subviews propagate MPI_Window of the original view
     dst.m_handle = ViewDataHandle<DstTraits>::assign(
         src.m_handle,
         src.m_offset(0, extents.domain_offset(1), extents.domain_offset(2),
                      extents.domain_offset(3), extents.domain_offset(4),
                      extents.domain_offset(5), extents.domain_offset(6),
-                     extents.domain_offset(7)), src.m_handle.win);
-    #else
+                     extents.domain_offset(7)),
+        src.m_handle.win);
+#else
     dst.m_handle = ViewDataHandle<DstTraits>::assign(
         src.m_handle,
         src.m_offset(0, extents.domain_offset(1), extents.domain_offset(2),
                      extents.domain_offset(3), extents.domain_offset(4),
                      extents.domain_offset(5), extents.domain_offset(6),
                      extents.domain_offset(7)));
-    #endif
+#endif
   }
 };
 

--- a/src/impl/mpispace/Kokkos_MPISpace_DataHandle.hpp
+++ b/src/impl/mpispace/Kokkos_MPISpace_DataHandle.hpp
@@ -59,8 +59,8 @@ struct MPIDataHandle {
   KOKKOS_INLINE_FUNCTION
   MPIDataHandle(MPIDataHandle<T, Traits> const &arg)
       : ptr(arg.ptr), win(arg.win) {}
-  //KOKKOS_INLINE_FUNCTION
-  //MPIDataHandle(T *ptr_, MPI_Win &win_) : ptr(ptr_), win(win_) {}
+  // KOKKOS_INLINE_FUNCTION
+  // MPIDataHandle(T *ptr_, MPI_Win &win_) : ptr(ptr_), win(win_) {}
 
   template <typename iType>
   KOKKOS_INLINE_FUNCTION MPIDataElement<T, Traits> operator()(
@@ -83,7 +83,7 @@ struct ViewDataHandle<
   using handle_type = MPIDataHandle<value_type, Traits>;
   using return_type = MPIDataElement<value_type, Traits>;
   using track_type  = Kokkos::Impl::SharedAllocationTracker;
-  
+
   // Fixme: Currently unused
   KOKKOS_INLINE_FUNCTION
   static handle_type assign(value_type *arg_data_ptr,
@@ -95,7 +95,7 @@ struct ViewDataHandle<
 
   template <class SrcHandleType>
   KOKKOS_INLINE_FUNCTION static handle_type assign(
-      SrcHandleType const arg_data_ptr, size_t offset, MPI_Win& win) {
+      SrcHandleType const arg_data_ptr, size_t offset, MPI_Win &win) {
     // FIXME: Invocation of handle_type constructor sets win to MPI_WIN_NULL
     // This is invoked by subview ViewMapping so subviews will likely fail
     return handle_type(arg_data_ptr + offset, win);

--- a/src/impl/mpispace/Kokkos_MPISpace_DataHandle.hpp
+++ b/src/impl/mpispace/Kokkos_MPISpace_DataHandle.hpp
@@ -62,7 +62,6 @@ struct MPIDataHandle {
   MPIDataHandle(MPIDataHandle<T, Traits> const &arg)
       : ptr(arg.ptr), win(arg.win), win_offset(arg.win_offset) {}
 
-
   template <typename iType>
   KOKKOS_INLINE_FUNCTION MPIDataElement<T, Traits> operator()(
       const int &pe, const iType &i) const {
@@ -98,7 +97,7 @@ struct ViewDataHandle<
   KOKKOS_INLINE_FUNCTION static handle_type assign(
       SrcHandleType const arg_data_ptr, size_t offset, MPI_Win &win) {
     return handle_type(arg_data_ptr + offset, win, offset);
-}
+  }
 };
 
 }  // namespace Impl


### PR DESCRIPTION
Propagate MPI_Window to subviews. Also note that this shared one MPI window when accessing one memory allocation which seems like the correct behavior. 