### PR TITLE
[WIP] Uncomment the use of MPI_Win_lock/MPI_Win_unlock

### DIFF
--- a/src/impl/mpispace/Kokkos_MPISpace.cpp
+++ b/src/impl/mpispace/Kokkos_MPISpace.cpp
@@ -118,12 +118,6 @@ void MPISpace::deallocate(void *const, const size_t) const {
   MPI_Win_unlock_all(current_win);
   MPI_Win_free(&current_win);
 
-  // We pass a mempory space instance do multiple Views thus
-  // setting "current_win = MPI_WIN_NULL;" will result in a wrong handle if
-  // subsequent view runs out of scope
-  // Fixme: The following only works when views are allocated sequentially
-  // We need a thread-safe map to associate views and windows
-
   if (last_valid != 0)
     current_win = mpi_windows[last_valid - 1];
   else

--- a/src/impl/mpispace/Kokkos_MPISpace_Ops.hpp
+++ b/src/impl/mpispace/Kokkos_MPISpace_Ops.hpp
@@ -56,11 +56,9 @@ namespace Impl {
     assert(win != MPI_WIN_NULL);                                               \
     int _typesize;                                                             \
     MPI_Type_size(mpi_type, &_typesize);                                       \
-    MPI_Win_lock(MPI_LOCK_SHARED, pe, 0, win);                                 \
     MPI_Put(&val, 1, mpi_type, pe,                                             \
             sizeof(SharedAllocationHeader) + offset * _typesize, 1, mpi_type,  \
             win);                                                              \
-    MPI_Win_unlock(pe, win);                                                   \
     MPI_Win_flush(pe, win);                                                    \
   }
 
@@ -85,11 +83,9 @@ KOKKOS_REMOTESPACES_P(double, MPI_DOUBLE)
     assert(win != MPI_WIN_NULL);                                              \
     int _typesize;                                                            \
     MPI_Type_size(mpi_type, &_typesize);                                      \
-    MPI_Win_lock(MPI_LOCK_SHARED, pe, 0, win);                                \
     MPI_Get(&val, 1, mpi_type, pe,                                            \
             sizeof(SharedAllocationHeader) + offset * _typesize, 1, mpi_type, \
             win);                                                             \
-    MPI_Win_unlock(pe, win);                                                  \
     MPI_Win_flush(pe, win);                                                   \
   }
 

--- a/src/impl/mpispace/Kokkos_MPISpace_Ops.hpp
+++ b/src/impl/mpispace/Kokkos_MPISpace_Ops.hpp
@@ -56,12 +56,12 @@ namespace Impl {
     assert(win != MPI_WIN_NULL);                                               \
     int _typesize;                                                             \
     MPI_Type_size(mpi_type, &_typesize);                                       \
-    /*MPI_Win_lock(MPI_LOCK_SHARED, pe, 0, win); */                            \
+    MPI_Win_lock(MPI_LOCK_SHARED, pe, 0, win);                                 \
     MPI_Put(&val, 1, mpi_type, pe,                                             \
             sizeof(SharedAllocationHeader) + offset * _typesize, 1, mpi_type,  \
             win);                                                              \
-    /* MPI_Win_unlock(pe, win);  */                                            \
-    MPI_Win_flush(0, win);                                                     \
+    MPI_Win_unlock(pe, win);                                                   \
+    MPI_Win_flush(pe, win);                                                    \
   }
 
 KOKKOS_REMOTESPACES_P(char, MPI_SIGNED_CHAR)
@@ -85,12 +85,12 @@ KOKKOS_REMOTESPACES_P(double, MPI_DOUBLE)
     assert(win != MPI_WIN_NULL);                                              \
     int _typesize;                                                            \
     MPI_Type_size(mpi_type, &_typesize);                                      \
-    /*MPI_Win_lock(MPI_LOCK_SHARED, 0, pe, win);*/                            \
+    MPI_Win_lock(MPI_LOCK_SHARED, pe, 0, win);                                \
     MPI_Get(&val, 1, mpi_type, pe,                                            \
             sizeof(SharedAllocationHeader) + offset * _typesize, 1, mpi_type, \
             win);                                                             \
-    /*MPI_Win_unlock(0, win);*/                                               \
-    MPI_Win_flush(0, win);                                                    \
+    MPI_Win_unlock(pe, win);                                                  \
+    MPI_Win_flush(pe, win);                                                   \
   }
 
 KOKKOS_REMOTESPACES_G(char, MPI_SIGNED_CHAR)


### PR DESCRIPTION
Restores the use of MPI_Win_lock/MPI_Win_unlock.
This currently fails the unit test as:

```
[1,0]<stdout>:[ RUN      ] TEST_CATEGORY.test_deepcopy
[weaver11:90579] *** An error occurred in MPI_Win_flush
[weaver11:90579] *** reported by process [3964796929,1]
[weaver11:90579] *** on win rdma window 3
[weaver11:90579] *** MPI_ERR_RMA_SYNC: error executing rma sync
[weaver11:90579] *** MPI_ERRORS_ARE_FATAL (processes in this win will now abort,
[weaver11:90579] ***    and potentially your MPI job)
```

Reproducer:
```
cmake .. -DCMAKE_CXX_COMPILER=mpicxx  -DKokkos_ENABLE_MPISPACE=On -Kokkos_ENABLE_TESTS=On
mpirun --tag-output --np 2 --npernode 2  unit_tests/KokkosRemote_TestAll
```

