### PR TITLE
CI with Kokkos 4.0.00

### DIFF
--- a/scripts/docker/Dockerfile.openmpi
+++ b/scripts/docker/Dockerfile.openmpi
@@ -88,13 +88,13 @@ ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
 ENV OMPI_MCA_btl_base_warn_component_unused='0'
 ENV PATH=${INSTALL_DIR}/openmpi/bin:$PATH
 
-## Install Kokkos (VERSION DEVELOP)
+## Install Kokkos (VERSION 4.0.00)
 RUN export KOKKOS_SOURCE_DIR=${SOURCE_DIR}/kokkos && \
     export KOKKOS_BUILD_DIR=${BUILD_DIR}/kokkos && \
     export KOKKOS_INSTALL_DIR=${INSTALL_DIR}/kokkos && \
     cd ${SOURCE_DIR} && git clone https://github.com/kokkos/kokkos && \
     cd kokkos && \
-    git checkout develop && \
+    git checkout 4.0.00 && \
     mkdir -p ${KOKKOS_BUILD_DIR} && \
     cd ${KOKKOS_BUILD_DIR} && \
     cmake -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
Set Kokkos version for CI testing to 4.0.00.