### PR TITLE
Add the "sma" name to cmake FindSHMEM module

### DIFF
--- a/modules/FindSHMEM.cmake
+++ b/modules/FindSHMEM.cmake
@@ -1,4 +1,4 @@
-find_library(shlib_found oshmem PATHS ${SHMEM_ROOT} SUFFIXES lib lib64 NO_DEFAULT_PATHS)
+find_library(shlib_found NAMES oshmem sma PATHS ${SHMEM_ROOT} SUFFIXES lib lib64 NO_DEFAULT_PATHS)
 find_path(shhdr_found shmem.h PATHS ${SHMEM_ROOT}/include NO_DEFAULT_PATHS)
 
 find_package_handle_standard_args(SHMEM DEFAULT_MSG shlib_found shhdr_found)


### PR DESCRIPTION
To support Sandia OpenSHMEM out-of-the-box, we need to add the `sma` as an acceptable library name in the `FindSHMEM.cmake` module.