### PR TITLE
updating old tutorial examples to compile

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,2 +1,4 @@
 add_subdirectory(cgsolve)
 add_subdirectory(benchmarks)
+add_subdirectory(matvec)
+add_subdirectory(vectorshift)

--- a/examples/matvec/multi-node/matvec.cpp
+++ b/examples/matvec/multi-node/matvec.cpp
@@ -30,7 +30,7 @@ using VALUE_T         = double;
 #define TEAM_SIZE 256
 #define VEC_LEN 1
 
-using RemoteSpace_t  = Kokkos::Experimental::DefaultRemoteMemorySpace;
+using RemoteSpace_t = Kokkos::Experimental::DefaultRemoteMemorySpace;
 using RemoteVector_t =
     Kokkos::View<VALUE_T **, Kokkos::PartitionedLayoutLeft, RemoteSpace_t>;
 using VectorHost_r_t =

--- a/examples/matvec/multi-node/matvec.cpp
+++ b/examples/matvec/multi-node/matvec.cpp
@@ -31,8 +31,12 @@ using VALUE_T         = double;
 #define VEC_LEN 1
 
 using RemoteSpace_t  = Kokkos::Experimental::DefaultRemoteMemorySpace;
-using RemoteVector_t = Kokkos::View<VALUE_T **, Kokkos::PartitionedLayoutLeft, RemoteSpace_t>;
-using VectorHost_r_t = Kokkos::View<VALUE_T **, Kokkos::PartitionedLayoutLeft, Kokkos::HostSpace>;
+using RemoteVector_t = Kokkos::View<VALUE_T **,
+                                    Kokkos::PartitionedLayoutLeft,
+                                    RemoteSpace_t>;
+using VectorHost_r_t = Kokkos::View<VALUE_T **,
+                                    Kokkos::PartitionedLayoutLeft,
+                                    Kokkos::HostSpace>;
 
 using VectorHost_t = Kokkos::View<VALUE_T *, Kokkos::HostSpace>;
 using MatrixHost_t = Kokkos::View<VALUE_T **, Kokkos::HostSpace>;

--- a/examples/matvec/multi-node/matvec.cpp
+++ b/examples/matvec/multi-node/matvec.cpp
@@ -31,8 +31,8 @@ using VALUE_T         = double;
 #define VEC_LEN 1
 
 using RemoteSpace_t  = Kokkos::Experimental::DefaultRemoteMemorySpace;
-using RemoteVector_t = Kokkos::View<VALUE_T **, RemoteSpace_t>;
-using VectorHost_r_t = Kokkos::View<VALUE_T **, Kokkos::HostSpace>;
+using RemoteVector_t = Kokkos::View<VALUE_T **, Kokkos::PartitionedLayoutLeft, RemoteSpace_t>;
+using VectorHost_r_t = Kokkos::View<VALUE_T **, Kokkos::PartitionedLayoutLeft, Kokkos::HostSpace>;
 
 using VectorHost_t = Kokkos::View<VALUE_T *, Kokkos::HostSpace>;
 using MatrixHost_t = Kokkos::View<VALUE_T **, Kokkos::HostSpace>;
@@ -64,6 +64,10 @@ int main(int argc, char *argv[]) {
   nvshmemx_init_attr(NVSHMEMX_INIT_WITH_MPI_COMM, &attr);
 #endif
 
+  int myRank, numRanks;
+  MPI_Comm_rank(MPI_COMM_WORLD, &myRank);
+  MPI_Comm_size(MPI_COMM_WORLD, &numRanks);
+
   // Vars
   float time = 0;
   ORDINAL_T nx;
@@ -93,7 +97,7 @@ int main(int argc, char *argv[]) {
     auto b = Kokkos::create_mirror_view_and_copy(Kokkos::CudaSpace(), b_h);
 
     // Copy host device data into global vector
-    Kokkos::Experimental::deep_copy(x, x_h);
+    Kokkos::deep_copy(x, x_h);
 
     Kokkos::Timer timer;
 

--- a/examples/matvec/multi-node/matvec.cpp
+++ b/examples/matvec/multi-node/matvec.cpp
@@ -31,12 +31,10 @@ using VALUE_T         = double;
 #define VEC_LEN 1
 
 using RemoteSpace_t  = Kokkos::Experimental::DefaultRemoteMemorySpace;
-using RemoteVector_t = Kokkos::View<VALUE_T **,
-                                    Kokkos::PartitionedLayoutLeft,
-                                    RemoteSpace_t>;
-using VectorHost_r_t = Kokkos::View<VALUE_T **,
-                                    Kokkos::PartitionedLayoutLeft,
-                                    Kokkos::HostSpace>;
+using RemoteVector_t =
+    Kokkos::View<VALUE_T **, Kokkos::PartitionedLayoutLeft, RemoteSpace_t>;
+using VectorHost_r_t =
+    Kokkos::View<VALUE_T **, Kokkos::PartitionedLayoutLeft, Kokkos::HostSpace>;
 
 using VectorHost_t = Kokkos::View<VALUE_T *, Kokkos::HostSpace>;
 using MatrixHost_t = Kokkos::View<VALUE_T **, Kokkos::HostSpace>;

--- a/examples/vectorshift/multi-node/CMakeLists.txt
+++ b/examples/vectorshift/multi-node/CMakeLists.txt
@@ -1,5 +1,3 @@
 add_executable(shift_multi vectorshift.cpp)
 target_link_libraries(shift_multi PRIVATE Kokkos::kokkosremote)
 target_include_directories(shift_multi PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-
-

--- a/examples/vectorshift/multi-node/vectorshift.cpp
+++ b/examples/vectorshift/multi-node/vectorshift.cpp
@@ -27,9 +27,9 @@
 #define SIZE 1024
 
 using RemoteSpace_t = Kokkos::Experimental::DefaultRemoteMemorySpace;
-using RemoteView_t  =
+using RemoteView_t =
     Kokkos::View<T **, Kokkos::PartitionedLayoutLeft, RemoteSpace_t>;
-using HostView_t    =
+using HostView_t =
     Kokkos::View<T **, Kokkos::PartitionedLayoutLeft, Kokkos::HostSpace>;
 
 #define swap(a, b, T) \

--- a/examples/vectorshift/multi-node/vectorshift.cpp
+++ b/examples/vectorshift/multi-node/vectorshift.cpp
@@ -27,12 +27,10 @@
 #define SIZE 1024
 
 using RemoteSpace_t = Kokkos::Experimental::DefaultRemoteMemorySpace;
-using RemoteView_t  = Kokkos::View<T **,
-                                   Kokkos::PartitionedLayoutLeft,
-                                   RemoteSpace_t>;
-using HostView_t    = Kokkos::View<T **,
-                                   Kokkos::PartitionedLayoutLeft,
-                                   Kokkos::HostSpace>;
+using RemoteView_t  =
+    Kokkos::View<T **, Kokkos::PartitionedLayoutLeft, RemoteSpace_t>;
+using HostView_t    =
+    Kokkos::View<T **, Kokkos::PartitionedLayoutLeft, Kokkos::HostSpace>;
 
 #define swap(a, b, T) \
   T tmp = a;          \

--- a/examples/vectorshift/multi-node/vectorshift.cpp
+++ b/examples/vectorshift/multi-node/vectorshift.cpp
@@ -106,11 +106,11 @@ int main(int argc, char *argv[]) {
       swap(a, b, RemoteView_t);
     }
     // Copy back to Host memory space
-    Kokkos::deep_copy(a_h, b);
+    Kokkos::deep_copy(a_h, a);
 
     // Correctness check on corresponding PE
     if (myPE == NUM_SHIFTS * OFFSET / myN) {
-      assert(a_h(0, (NUM_SHIFTS * OFFSET % myN) - 1) == 1);
+      assert(a_h(0, (NUM_SHIFTS * OFFSET % myN)) == 1);
     }
   }
 

--- a/examples/vectorshift/multi-node/vectorshift.cpp
+++ b/examples/vectorshift/multi-node/vectorshift.cpp
@@ -27,8 +27,8 @@
 #define SIZE 1024
 
 using RemoteSpace_t = Kokkos::Experimental::DefaultRemoteMemorySpace;
-using RemoteView_t  = Kokkos::View<T **, RemoteSpace_t>;
-using HostView_t    = Kokkos::View<T **, Kokkos::HostSpace>;
+using RemoteView_t  = Kokkos::View<T **, Kokkos::PartitionedLayoutLeft, RemoteSpace_t>;
+using HostView_t    = Kokkos::View<T **, Kokkos::PartitionedLayoutLeft, Kokkos::HostSpace>;
 
 #define swap(a, b, T) \
   T tmp = a;          \
@@ -87,7 +87,7 @@ int main(int argc, char *argv[]) {
     a_h(0, 0) = 1;
 
     // Copy to Remote Memory Space
-    Kokkos::Experimental::deep_copy(a, a_h);
+    Kokkos::deep_copy(a, a_h);
 
     for (int shift = 0; shift < NUM_SHIFTS; ++shift) {
       // Iteration space over global array
@@ -106,7 +106,7 @@ int main(int argc, char *argv[]) {
       swap(a, b, RemoteView_t);
     }
     // Copy back to Host memory space
-    Kokkos::Experimental::deep_copy(a_h, b);
+    Kokkos::deep_copy(a_h, b);
 
     // Correctness check on corresponding PE
     if (myPE == NUM_SHIFTS * OFFSET / myN) {

--- a/examples/vectorshift/multi-node/vectorshift.cpp
+++ b/examples/vectorshift/multi-node/vectorshift.cpp
@@ -27,8 +27,12 @@
 #define SIZE 1024
 
 using RemoteSpace_t = Kokkos::Experimental::DefaultRemoteMemorySpace;
-using RemoteView_t  = Kokkos::View<T **, Kokkos::PartitionedLayoutLeft, RemoteSpace_t>;
-using HostView_t    = Kokkos::View<T **, Kokkos::PartitionedLayoutLeft, Kokkos::HostSpace>;
+using RemoteView_t  = Kokkos::View<T **,
+                                   Kokkos::PartitionedLayoutLeft,
+                                   RemoteSpace_t>;
+using HostView_t    = Kokkos::View<T **,
+                                   Kokkos::PartitionedLayoutLeft,
+                                   Kokkos::HostSpace>;
 
 #define swap(a, b, T) \
   T tmp = a;          \

--- a/examples/vectorshift/single-node/vectorshift.cpp
+++ b/examples/vectorshift/single-node/vectorshift.cpp
@@ -98,10 +98,10 @@ int main(int argc, char *argv[]) {
       swap(a, b, View_t);
     }
 
-    Kokkos::deep_copy(a_h, b);
+    Kokkos::deep_copy(a_h, a);
     // Excersize: Update error check to check if value "1" has been shifter
     // Note: it resides porentially on a different PE
-    assert(a_h((NUM_SHIFTS * OFFSET % n) - 1) == 1);
+    assert(a_h((NUM_SHIFTS * OFFSET % n)) == 1);
   }
   Kokkos::finalize();
 


### PR DESCRIPTION
Adding `Kokkos::PartitionedLayoutLeft` to the matvec and vectorshift examples, and the MPI rank determination to matvec. This allows the code to compile and run once again!

On weaver with my current setup, I find I get the following message at runtime (though it seems to be benign):
```
home/jciesko/software/nvshmem_src_2.9.0-2/src/comm/transports/ibrc/ibrc.cpp:nvshmemt_init:1746: neither nv_peer_mem, or nvidia_peermem detected. Skipping transport. 
```