### PR TITLE
Make interoperability work with Kokkos Kernels

### DIFF
--- a/src/impl/mpispace/Kokkos_MPISpace_DataHandle.hpp
+++ b/src/impl/mpispace/Kokkos_MPISpace_DataHandle.hpp
@@ -41,7 +41,7 @@ struct MPIDataHandle {
 
   template <typename SrcTraits>
   KOKKOS_INLINE_FUNCTION MPIDataHandle(SrcTraits const &arg)
-      : : ptr(arg.ptr), win(arg.win), win_offset(arg.win_offset) {}
+      : ptr(arg.ptr), win(arg.win), win_offset(arg.win_offset) {}
 
   template <typename iType>
   KOKKOS_INLINE_FUNCTION MPIDataElement<T, Traits> operator()(

--- a/src/impl/mpispace/Kokkos_MPISpace_DataHandle.hpp
+++ b/src/impl/mpispace/Kokkos_MPISpace_DataHandle.hpp
@@ -27,14 +27,21 @@ struct MPIDataHandle {
   T *ptr;
   mutable MPI_Win win;
   size_t win_offset;
+
   KOKKOS_INLINE_FUNCTION
   MPIDataHandle() : ptr(NULL), win(MPI_WIN_NULL), win_offset(0) {}
+
   KOKKOS_INLINE_FUNCTION
   MPIDataHandle(T *ptr_, MPI_Win &win_, size_t offset_ = 0)
       : ptr(ptr_), win(win_), win_offset(offset_) {}
+
   KOKKOS_INLINE_FUNCTION
   MPIDataHandle(MPIDataHandle<T, Traits> const &arg)
       : ptr(arg.ptr), win(arg.win), win_offset(arg.win_offset) {}
+
+  template <typename SrcTraits>
+  KOKKOS_INLINE_FUNCTION MPIDataHandle(SrcTraits const &arg)
+      : : ptr(arg.ptr), win(arg.win), win_offset(arg.win_offset) {}
 
   template <typename iType>
   KOKKOS_INLINE_FUNCTION MPIDataElement<T, Traits> operator()(
@@ -58,19 +65,33 @@ struct ViewDataHandle<
   using return_type = MPIDataElement<value_type, Traits>;
   using track_type  = Kokkos::Impl::SharedAllocationTracker;
 
-  // Fixme: Currently unused
+  template <class SrcHandleType>
+  KOKKOS_INLINE_FUNCTION static handle_type assign(
+      SrcHandleType const &arg_data_ptr, track_type const & /*arg_tracker*/) {
+    return handle_type(arg_data_ptr);
+  }
+
   KOKKOS_INLINE_FUNCTION
   static handle_type assign(value_type *arg_data_ptr,
-                            track_type const &arg_tracker) {
-    return handle_type(
-        arg_data_ptr,
-        arg_tracker.template get_record<Kokkos::Experimental::MPISpace>()->win);
+                            track_type const & /*arg_tracker*/) {
+    return handle_type(arg_data_ptr);
   }
 
   template <class SrcHandleType>
   KOKKOS_INLINE_FUNCTION static handle_type assign(
-      SrcHandleType const arg_data_ptr, size_t offset, MPI_Win &win) {
-    return handle_type(arg_data_ptr + offset, win, offset);
+      SrcHandleType const arg_data_ptr, size_t offset) {
+    return handle_type(arg_data_ptr + offset);
+  }
+
+  template <class SrcHandleType>
+  KOKKOS_INLINE_FUNCTION static handle_type assign(
+      SrcHandleType const arg_data_ptr) {
+    return handle_type(arg_data_ptr);
+  }
+
+  template <class SrcHandleType>
+  KOKKOS_INLINE_FUNCTION handle_type operator=(SrcHandleType const &rhs) {
+    return handle_type(rhs);
   }
 };
 

--- a/src/impl/mpispace/Kokkos_MPISpace_ViewTraits.hpp
+++ b/src/impl/mpispace/Kokkos_MPISpace_ViewTraits.hpp
@@ -51,6 +51,34 @@ struct ViewTraits<void, Kokkos::Experimental::MPISpace, Properties...> {
   using hooks_policy  = typename ViewTraits<void, Properties...>::hooks_policy;
 };
 
+template <class... Properties>
+struct ViewTraits<
+    void, Kokkos::Device<Kokkos::HostSpace, Kokkos::Experimental::MPISpace>,
+    Properties...> {
+  static_assert(
+      std::is_same<typename ViewTraits<void, Properties...>::execution_space,
+                   void>::value &&
+          std::is_same<typename ViewTraits<void, Properties...>::memory_space,
+                       void>::value &&
+          std::is_same<
+              typename ViewTraits<void, Properties...>::HostMirrorSpace,
+              void>::value &&
+          std::is_same<typename ViewTraits<void, Properties...>::array_layout,
+                       void>::value,
+      "Only one View Execution or Memory Space template argument");
+
+  // Specify layout, keep subsequent space and memory traits arguments
+  using execution_space =
+      typename Kokkos::Experimental::MPISpace::execution_space;
+  using memory_space = typename Kokkos::Experimental::MPISpace::memory_space;
+  using HostMirrorSpace =
+      typename Kokkos::Impl::HostMirror<Kokkos::Experimental::MPISpace>::Space;
+  using array_layout  = typename execution_space::array_layout;
+  using specialize    = Kokkos::Experimental::RemoteSpaceSpecializeTag;
+  using memory_traits = typename ViewTraits<void, Properties...>::memory_traits;
+  using hooks_policy  = typename ViewTraits<void, Properties...>::hooks_policy;
+};
+
 }  // namespace Kokkos
 
 #endif  // KOKKOS_REMOTESPACES_MPI_VIEWTRAITS_HPP

--- a/src/impl/nvshmemspace/Kokkos_NVSHMEMSpace_DataHandle.hpp
+++ b/src/impl/nvshmemspace/Kokkos_NVSHMEMSpace_DataHandle.hpp
@@ -25,12 +25,19 @@ namespace Impl {
 template <class T, class Traits>
 struct NVSHMEMDataHandle {
   T *ptr;
+
   KOKKOS_INLINE_FUNCTION
   NVSHMEMDataHandle() : ptr(NULL) {}
+
   KOKKOS_INLINE_FUNCTION
   NVSHMEMDataHandle(T *ptr_) : ptr(ptr_) {}
+
   KOKKOS_INLINE_FUNCTION
   NVSHMEMDataHandle(NVSHMEMDataHandle<T, Traits> const &arg) : ptr(arg.ptr) {}
+
+  template <typename SrcTraits>
+  KOKKOS_INLINE_FUNCTION NVSHMEMDataHandle(SrcTraits const &arg)
+      : ptr(arg.ptr) {}
 
   template <typename iType>
   KOKKOS_INLINE_FUNCTION NVSHMEMDataElement<T, Traits> operator()(
@@ -45,13 +52,19 @@ struct NVSHMEMDataHandle {
 
 template <class Traits>
 struct ViewDataHandle<
-    Traits, typename std::enable_if<std::is_same<
+    Traits, typename std::enable_if_t<std::is_same<
                 typename Traits::specialize,
-                Kokkos::Experimental::RemoteSpaceSpecializeTag>::value>::type> {
+                Kokkos::Experimental::RemoteSpaceSpecializeTag>::value>> {
   using value_type  = typename Traits::value_type;
   using handle_type = NVSHMEMDataHandle<value_type, Traits>;
   using return_type = NVSHMEMDataElement<value_type, Traits>;
   using track_type  = Kokkos::Impl::SharedAllocationTracker;
+
+  template <class SrcHandleType>
+  KOKKOS_INLINE_FUNCTION static handle_type assign(
+      SrcHandleType const &arg_data_ptr, track_type const & /*arg_tracker*/) {
+    return handle_type(arg_data_ptr);
+  }
 
   KOKKOS_INLINE_FUNCTION
   static handle_type assign(value_type *arg_data_ptr,

--- a/src/impl/nvshmemspace/Kokkos_NVSHMEMSpace_Ops.hpp
+++ b/src/impl/nvshmemspace/Kokkos_NVSHMEMSpace_Ops.hpp
@@ -791,8 +791,7 @@ struct NVSHMEMDataElement<
 
   KOKKOS_INLINE_FUNCTION
   operator const_value_type() const {
-    T tmp;
-    tmp = shmem_type_g(ptr, pe);
+    T tmp = shmem_type_g((double *)ptr, pe);
     return tmp;
   }
 };

--- a/src/impl/nvshmemspace/Kokkos_NVSHMEMSpace_ViewTraits.hpp
+++ b/src/impl/nvshmemspace/Kokkos_NVSHMEMSpace_ViewTraits.hpp
@@ -51,6 +51,33 @@ struct ViewTraits<void, Kokkos::Experimental::NVSHMEMSpace, Properties...> {
   using hooks_policy  = typename ViewTraits<void, Properties...>::hooks_policy;
 };
 
+template <class... Properties>
+struct ViewTraits<
+    void, Kokkos::Device<Kokkos::Cuda, Kokkos::Experimental::NVSHMEMSpace>,
+    Properties...> {
+  static_assert(
+      std::is_same<typename ViewTraits<void, Properties...>::execution_space,
+                   void>::value &&
+          std::is_same<typename ViewTraits<void, Properties...>::memory_space,
+                       void>::value &&
+          std::is_same<
+              typename ViewTraits<void, Properties...>::HostMirrorSpace,
+              void>::value &&
+          std::is_same<typename ViewTraits<void, Properties...>::array_layout,
+                       void>::value,
+      "Only one View Execution or Memory Space template argument");
+
+  // Specify layout, keep subsequent space and memory traits arguments
+  using execution_space = Kokkos::Cuda;
+  using memory_space    = Kokkos::Experimental::NVSHMEMSpace;
+  using HostMirrorSpace = typename Kokkos::Impl::HostMirror<
+      Kokkos::Experimental::NVSHMEMSpace>::Space;
+  using array_layout  = typename execution_space::array_layout;
+  using specialize    = Kokkos::Experimental::RemoteSpaceSpecializeTag;
+  using memory_traits = typename ViewTraits<void, Properties...>::memory_traits;
+  using hooks_policy  = typename ViewTraits<void, Properties...>::hooks_policy;
+};
+
 }  // namespace Kokkos
 
 #endif  // KOKKOS_REMOTESPACES_NVSHMEM_VIEWTRAITS_HPP

--- a/src/impl/shmemspace/Kokkos_SHMEMSpace_DataHandle.hpp
+++ b/src/impl/shmemspace/Kokkos_SHMEMSpace_DataHandle.hpp
@@ -25,12 +25,18 @@ namespace Impl {
 template <class T, class Traits>
 struct SHMEMDataHandle {
   T *ptr;
+
   KOKKOS_INLINE_FUNCTION
   SHMEMDataHandle() : ptr(NULL) {}
+
   KOKKOS_INLINE_FUNCTION
   SHMEMDataHandle(T *ptr_) : ptr(ptr_) {}
+
   KOKKOS_INLINE_FUNCTION
   SHMEMDataHandle(SHMEMDataHandle<T, Traits> const &arg) : ptr(arg.ptr) {}
+
+  template <typename SrcTraits>
+  KOKKOS_INLINE_FUNCTION SHMEMDataHandle(SrcTraits const &arg) : ptr(arg.ptr) {}
 
   template <typename iType>
   KOKKOS_INLINE_FUNCTION SHMEMDataElement<T, Traits> operator()(
@@ -52,6 +58,12 @@ struct ViewDataHandle<
   using handle_type = SHMEMDataHandle<value_type, Traits>;
   using return_type = SHMEMDataElement<value_type, Traits>;
   using track_type  = Kokkos::Impl::SharedAllocationTracker;
+
+  template <class SrcHandleType>
+  KOKKOS_INLINE_FUNCTION static handle_type assign(
+      SrcHandleType const &arg_data_ptr, track_type const & /*arg_tracker*/) {
+    return handle_type(arg_data_ptr);
+  }
 
   KOKKOS_INLINE_FUNCTION
   static handle_type assign(value_type *arg_data_ptr,

--- a/src/impl/shmemspace/Kokkos_SHMEMSpace_Ops.hpp
+++ b/src/impl/shmemspace/Kokkos_SHMEMSpace_Ops.hpp
@@ -788,8 +788,7 @@ struct SHMEMDataElement<
 
   KOKKOS_INLINE_FUNCTION
   operator const_value_type() const {
-    T tmp;
-    tmp = shmem_type_g(ptr, pe);
+    T tmp = shmem_type_g(ptr, pe);
     return tmp;
   }
 };

--- a/src/impl/shmemspace/Kokkos_SHMEMSpace_ViewTraits.hpp
+++ b/src/impl/shmemspace/Kokkos_SHMEMSpace_ViewTraits.hpp
@@ -51,6 +51,34 @@ struct ViewTraits<void, Kokkos::Experimental::SHMEMSpace, Properties...> {
   using hooks_policy  = typename ViewTraits<void, Properties...>::hooks_policy;
 };
 
+template <class... Properties>
+struct ViewTraits<
+    void, Kokkos::Device<Kokkos::HostSpace, Kokkos::Experimental::SHMEMSpace>,
+    Properties...> {
+  static_assert(
+      std::is_same<typename ViewTraits<void, Properties...>::execution_space,
+                   void>::value &&
+          std::is_same<typename ViewTraits<void, Properties...>::memory_space,
+                       void>::value &&
+          std::is_same<
+              typename ViewTraits<void, Properties...>::HostMirrorSpace,
+              void>::value &&
+          std::is_same<typename ViewTraits<void, Properties...>::array_layout,
+                       void>::value,
+      "Only one View Execution or Memory Space template argument");
+
+  // Specify layout, keep subsequent space and memory traits arguments
+  using execution_space =
+      typename Kokkos::Experimental::SHMEMSpace::execution_space;
+  using memory_space = typename Kokkos::Experimental::SHMEMSpace::memory_space;
+  using HostMirrorSpace = typename Kokkos::Impl::HostMirror<
+      Kokkos::Experimental::SHMEMSpace>::Space;
+  using array_layout  = typename execution_space::array_layout;
+  using specialize    = Kokkos::Experimental::RemoteSpaceSpecializeTag;
+  using memory_traits = typename ViewTraits<void, Properties...>::memory_traits;
+  using hooks_policy  = typename ViewTraits<void, Properties...>::hooks_policy;
+};
+
 }  // namespace Kokkos
 
 #endif  // KOKKOS_REMOTESPACES_SHMEM_VIEWTRAITS_HPP


### PR DESCRIPTION
- Fixes compilation errors when copy-constructing remote views.
- Some minor changes.