### PR TITLE
Update CUDA img to newer version

### DIFF
--- a/scripts/docker/Dockerfile.clang
+++ b/scripts/docker/Dockerfile.clang
@@ -1,4 +1,5 @@
-FROM nvidia/cuda:9.2-devel
+ARG BASE=nvcr.io/nvidia/cuda:12.2.0-devel-ubuntu20.04
+FROM $BASE
 
 RUN apt-get update && apt-get install -y \
         bc \


### PR DESCRIPTION
Nvidia removed a bunch of docker images. We need to use a newer one. Thanks @Rombur for pointing that out.