### PR TITLE
Minor updates for Kokkos 4.3 compatibility

### DIFF
--- a/src/impl/mpispace/Kokkos_MPISpace.hpp
+++ b/src/impl/mpispace/Kokkos_MPISpace.hpp
@@ -75,8 +75,10 @@ class MPISpace {
                   const size_t arg_logical_size = 0) const;
 
  private:
+#if (KOKKOS_VERSION < 40300)
   template <class, class, class, class>
   friend class Kokkos::Experimental::LogicalMemorySpace;
+#endif
 
   void *impl_allocate(const char *arg_label, const size_t arg_alloc_size,
                       const size_t arg_logical_size = 0,

--- a/src/impl/mpispace/Kokkos_MPISpace.hpp
+++ b/src/impl/mpispace/Kokkos_MPISpace.hpp
@@ -75,11 +75,6 @@ class MPISpace {
                   const size_t arg_logical_size = 0) const;
 
  private:
-#if (KOKKOS_VERSION < 40300)
-  template <class, class, class, class>
-  friend class Kokkos::Experimental::LogicalMemorySpace;
-#endif
-
   void *impl_allocate(const char *arg_label, const size_t arg_alloc_size,
                       const size_t arg_logical_size = 0,
                       const Kokkos::Tools::SpaceHandle =

--- a/src/impl/mpispace/Kokkos_MPISpace_AllocationRecord.cpp
+++ b/src/impl/mpispace/Kokkos_MPISpace_AllocationRecord.cpp
@@ -77,8 +77,12 @@ SharedAllocationRecord<Kokkos::Experimental::MPISpace, void>::
           sizeof(SharedAllocationHeader) + arg_alloc_size, arg_dealloc,
           arg_label),
       m_space(arg_space) {
+#if (KOKKOS_VERSION >= 40300)
+  fill_host_accessible_header_info(this, *RecordBase::m_alloc_ptr, arg_label);
+#else
   this->base_t::_fill_host_accessible_header_info(*RecordBase::m_alloc_ptr,
                                                   arg_label);
+#endif
   win = m_space.current_win;
 }
 

--- a/src/impl/mpispace/Kokkos_MPISpace_AllocationRecord.hpp
+++ b/src/impl/mpispace/Kokkos_MPISpace_AllocationRecord.hpp
@@ -68,8 +68,12 @@ class SharedAllocationRecord<Kokkos::Experimental::MPISpace, void>
             sizeof(SharedAllocationHeader) + arg_alloc_size, arg_dealloc,
             arg_label),
         m_space(arg_space) {
+#if (KOKKOS_VERSION >= 40300)
+    fill_host_accessible_header_info(this, *RecordBase::m_alloc_ptr, arg_label);
+#else
     this->base_t::_fill_host_accessible_header_info(*RecordBase::m_alloc_ptr,
                                                     arg_label);
+#endif
   }
 
   SharedAllocationRecord(

--- a/src/impl/nvshmemspace/Kokkos_NVSHMEMSpace.hpp
+++ b/src/impl/nvshmemspace/Kokkos_NVSHMEMSpace.hpp
@@ -67,11 +67,6 @@ class NVSHMEMSpace {
                   const size_t arg_logical_size = 0) const;
 
  private:
-#if (KOKKOS_VERSION < 40300)
-  template <class, class, class, class>
-  friend class Kokkos::Experimental::LogicalMemorySpace;
-#endif
-
   void *impl_allocate(const char *arg_label, const size_t arg_alloc_size,
                       const size_t arg_logical_size = 0,
                       const Kokkos::Tools::SpaceHandle =

--- a/src/impl/nvshmemspace/Kokkos_NVSHMEMSpace.hpp
+++ b/src/impl/nvshmemspace/Kokkos_NVSHMEMSpace.hpp
@@ -67,8 +67,10 @@ class NVSHMEMSpace {
                   const size_t arg_logical_size = 0) const;
 
  private:
+#if (KOKKOS_VERSION < 40300)
   template <class, class, class, class>
   friend class Kokkos::Experimental::LogicalMemorySpace;
+#endif
 
   void *impl_allocate(const char *arg_label, const size_t arg_alloc_size,
                       const size_t arg_logical_size = 0,

--- a/src/impl/rocshmemspace/Kokkos_ROCSHMEMSpace.hpp
+++ b/src/impl/rocshmemspace/Kokkos_ROCSHMEMSpace.hpp
@@ -65,8 +65,10 @@ class ROCSHMEMSpace {
                   const size_t arg_logical_size = 0) const;
 
  private:
+#if (KOKKOS_VERSION < 40300)
   template <class, class, class, class>
   friend class Kokkos::Experimental::LogicalMemorySpace;
+#endif
 
   void *impl_allocate(const char *arg_label, const size_t arg_alloc_size,
                       const size_t arg_logical_size = 0,

--- a/src/impl/rocshmemspace/Kokkos_ROCSHMEMSpace.hpp
+++ b/src/impl/rocshmemspace/Kokkos_ROCSHMEMSpace.hpp
@@ -65,11 +65,6 @@ class ROCSHMEMSpace {
                   const size_t arg_logical_size = 0) const;
 
  private:
-#if (KOKKOS_VERSION < 40300)
-  template <class, class, class, class>
-  friend class Kokkos::Experimental::LogicalMemorySpace;
-#endif
-
   void *impl_allocate(const char *arg_label, const size_t arg_alloc_size,
                       const size_t arg_logical_size = 0,
                       const Kokkos::Tools::SpaceHandle =

--- a/src/impl/shmemspace/Kokkos_SHMEMSpace.hpp
+++ b/src/impl/shmemspace/Kokkos_SHMEMSpace.hpp
@@ -75,8 +75,10 @@ class SHMEMSpace {
                   const size_t arg_logical_size = 0) const;
 
  private:
+#if (KOKKOS_VERSION < 40300)
   template <class, class, class, class>
   friend class Kokkos::Experimental::LogicalMemorySpace;
+#endif
 
   void *impl_allocate(const char *arg_label, const size_t arg_alloc_size,
                       const size_t arg_logical_size = 0,

--- a/src/impl/shmemspace/Kokkos_SHMEMSpace.hpp
+++ b/src/impl/shmemspace/Kokkos_SHMEMSpace.hpp
@@ -75,11 +75,6 @@ class SHMEMSpace {
                   const size_t arg_logical_size = 0) const;
 
  private:
-#if (KOKKOS_VERSION < 40300)
-  template <class, class, class, class>
-  friend class Kokkos::Experimental::LogicalMemorySpace;
-#endif
-
   void *impl_allocate(const char *arg_label, const size_t arg_alloc_size,
                       const size_t arg_logical_size = 0,
                       const Kokkos::Tools::SpaceHandle =

--- a/src/impl/shmemspace/Kokkos_SHMEMSpace_AllocationRecord.cpp
+++ b/src/impl/shmemspace/Kokkos_SHMEMSpace_AllocationRecord.cpp
@@ -77,8 +77,12 @@ SharedAllocationRecord<Kokkos::Experimental::SHMEMSpace, void>::
           sizeof(SharedAllocationHeader) + arg_alloc_size, arg_dealloc,
           arg_label),
       m_space(arg_space) {
+#if (KOKKOS_VERSION >= 40300)
+  fill_host_accessible_header_info(this, *RecordBase::m_alloc_ptr, arg_label);
+#else
   this->base_t::_fill_host_accessible_header_info(*RecordBase::m_alloc_ptr,
                                                   arg_label);
+#endif
 }
 
 }  // namespace Impl

--- a/src/impl/shmemspace/Kokkos_SHMEMSpace_AllocationRecord.hpp
+++ b/src/impl/shmemspace/Kokkos_SHMEMSpace_AllocationRecord.hpp
@@ -68,8 +68,12 @@ class SharedAllocationRecord<Kokkos::Experimental::SHMEMSpace, void>
             sizeof(SharedAllocationHeader) + arg_alloc_size, arg_dealloc,
             arg_label),
         m_space(arg_space) {
+#if (KOKKOS_VERSION >= 40300)
+    fill_host_accessible_header_info(this, *RecordBase::m_alloc_ptr, arg_label);
+#else
     this->base_t::_fill_host_accessible_header_info(*RecordBase::m_alloc_ptr,
                                                     arg_label);
+#endif
   }
 
   SharedAllocationRecord(


### PR DESCRIPTION
Small changes to enable building with Kokkos 4.3 (current master branch).
All changes are guarded with macros, so building with previous versions isn't affected.

I tested my application with SHMEMSpace and NVSHMEMSpace and those built and ran correctly with these changes.
MPISpace has an issue though - not sure if it has to do with these changes, or if it's something else with 4.3:
```
.../kokkos-remote-spaces/src/impl/mpispace/Kokkos_MPISpace.cpp:164: void Kokkos::Experimental::MPISpace::impl_deallocate(const char*, void*, size_t, size_t, Kokkos::Tools::SpaceHandle) const: Assertion `current_win != (static_cast<MPI_Win> (static_cast<void *> (&(ompi_mpi_win_null))))' failed.
.../kokkos-remote-spaces/src/impl/mpispace/Kokkos_MPISpace.cpp:164: void Kokkos::Experimental::MPISpace::impl_deallocate(const char*, void*, size_t, size_t, Kokkos::Tools::SpaceHandle) const: Assertion `current_win != (static_cast<MPI_Win> (static_cast<void *> (&(ompi_mpi_win_null))))' failed.
```