### PR TITLE
Fix build with MPI backend

### DIFF
--- a/src/impl/mpispace/Kokkos_MPISpace_BlockOps.hpp
+++ b/src/impl/mpispace/Kokkos_MPISpace_BlockOps.hpp
@@ -19,7 +19,7 @@
 #ifndef KOKKOS_REMOTESPACES_MPISPACE_BLOCK_OPS_HPP
 #define KOKKOS_REMOTESPACES_MPISPACE_BLOCK_OPS_HPP
 
-#include <shmem.h>
+#include <mpi.h>
 #include <type_traits>
 
 namespace Kokkos {


### PR DESCRIPTION
Include mpi.h, not shmem.h in file for MPI backend