### PR TITLE
Update to use clang-format 16

### DIFF
--- a/applications/cgsolve/mpi/cgsolve.cpp
+++ b/applications/cgsolve/mpi/cgsolve.cpp
@@ -57,8 +57,8 @@ void spmv(YType y, AType A, XType x, SendRecvLists &srl) {
       KOKKOS_LAMBDA(const Kokkos::TeamPolicy<>::member_type &team) {
         const int64_t first_row = team.league_rank() * rows_per_team;
         const int64_t last_row  = first_row + rows_per_team < nrows
-                                     ? first_row + rows_per_team
-                                     : nrows;
+                                      ? first_row + rows_per_team
+                                      : nrows;
         Kokkos::parallel_for(
             Kokkos::TeamThreadRange(team, first_row, last_row),
             [&](const int64_t row) {

--- a/applications/cgsolve/mpi/generate_matrix.hpp
+++ b/applications/cgsolve/mpi/generate_matrix.hpp
@@ -29,7 +29,7 @@
 
 #define LOCAL_ORDINAL int64_t
 
-//#define MASK 1099511627776
+// #define MASK 1099511627776
 #define MASK 268435456
 template <class MemSpace>
 struct CrsMatrix {
@@ -266,7 +266,7 @@ Kokkos::View<double *, Kokkos::HostSpace> generate_miniFE_vector(int64_t nx) {
 #else
   int64_t block = (nrows + numRanks - 1) / numRanks;
   int64_t start = block * myRank;
-  int64_t end = start + block;
+  int64_t end   = start + block;
   if (end > nrows) end = nrows;
 #endif
 

--- a/applications/cgsolve/rma/cgsolve.cpp
+++ b/applications/cgsolve/rma/cgsolve.cpp
@@ -22,7 +22,7 @@
 */
 
 #define USE_GLOBAL_LAYOUT
-//#define USE_EXPLICIT_INDEXING
+// #define USE_EXPLICIT_INDEXING
 
 #include <Kokkos_RemoteSpaces.hpp>
 #include <generate_matrix.hpp>
@@ -65,8 +65,8 @@ void spmv(YType y, AType A, XType x) {
       KOKKOS_LAMBDA(const Kokkos::TeamPolicy<>::member_type &team) {
         const int64_t first_row = team.league_rank() * rows_per_team;
         const int64_t last_row  = first_row + rows_per_team < nrows
-                                     ? first_row + rows_per_team
-                                     : nrows;
+                                      ? first_row + rows_per_team
+                                      : nrows;
         Kokkos::parallel_for(Kokkos::TeamThreadRange(team, first_row, last_row),
                              [&](const int64_t row) {
                                const int64_t row_start = A.row_ptr(row);
@@ -301,8 +301,8 @@ int main(int argc, char *argv[]) {
 #else
       printf(
           "ranks, N, num_iters, total_flops, time, GFlops, BW(GB/sec), %i, %i, "
-          "%i, %.2e, "
-          "%.6lf, %.6lf, %.6lf\n",
+              "%i, %.2e, "
+              "%.6lf, %.6lf, %.6lf\n",
           numRanks, N, num_iters, total_flops, time, GFlops, GBs);
 #endif
     }

--- a/applications/cgsolve/rma/generate_matrix.hpp
+++ b/applications/cgsolve/rma/generate_matrix.hpp
@@ -52,7 +52,7 @@
 
 #define LOCAL_ORDINAL int64_t
 
-//#define MASK 1099511627776
+// #define MASK 1099511627776
 #define MASK 268435456
 template <class MemSpace>
 struct CrsMatrix {

--- a/applications/cgsolve/serial/cgsolve.cpp
+++ b/applications/cgsolve/serial/cgsolve.cpp
@@ -41,8 +41,8 @@ void spmv(YType y, AType A, XType x) {
       KOKKOS_LAMBDA(const Kokkos::TeamPolicy<>::member_type& team) {
         const int64_t first_row = team.league_rank() * rows_per_team;
         const int64_t last_row  = first_row + rows_per_team < nrows
-                                     ? first_row + rows_per_team
-                                     : nrows;
+                                      ? first_row + rows_per_team
+                                      : nrows;
         Kokkos::parallel_for(Kokkos::TeamThreadRange(team, first_row, last_row),
                              [&](const int64_t row) {
                                const int64_t row_start = A.row_ptr(row);

--- a/benchmarks/access_overhead/access_overhead_p2p.cpp
+++ b/benchmarks/access_overhead/access_overhead_p2p.cpp
@@ -26,7 +26,7 @@
 
 #define LDC_LEAGUE_SIZE 4096
 #define LDC_TEAM_SIZE 1
-//#define CHECK_FOR_CORRECTNESS
+// #define CHECK_FOR_CORRECTNESS
 
 using RemoteSpace_t = Kokkos::Experimental::DefaultRemoteMemorySpace;
 using RemoteView_t  = Kokkos::View<double *, RemoteSpace_t>;

--- a/benchmarks/randomaccess/randomaccess.cpp
+++ b/benchmarks/randomaccess/randomaccess.cpp
@@ -26,12 +26,12 @@
 
 // Select View-type
 #define USE_GLOBAL_LAYOUT
-//#define USE_PARTITIONED_LAYOUT
-//#define USE_LOCAL_LAYOUT
+// #define USE_PARTITIONED_LAYOUT
+// #define USE_LOCAL_LAYOUT
 
 // Select generator-type
 #define GENMODE genmode::random_sequence
-//#define GENMODE genmode::linear_sequence
+// #define GENMODE genmode::linear_sequence
 
 // Default values
 #define SIZE 1024
@@ -165,7 +165,7 @@ int main(int argc, char *argv[]) {
     ORDINAL_T end_idx = my_rank == num_ranks - 1
                             ? num_elems
                             : default_end + (num_elems - default_end) * spread;
-    idx_range = end_idx - start_idx;
+    idx_range         = end_idx - start_idx;
 
 #if defined(USE_PARTITIONED_LAYOUT)
     View_t v("PartitionedView", num_ranks, num_elems_per_rank);

--- a/scripts/apply-clang-format
+++ b/scripts/apply-clang-format
@@ -13,8 +13,8 @@ CLANG_FORMAT_VERSION="$(${CLANG_FORMAT_EXECUTABLE} --version)"
 CLANG_FORMAT_MAJOR_VERSION=$(echo "${CLANG_FORMAT_VERSION}" | sed 's/^[^0-9]*\([0-9]*\).*$/\1/g')
 CLANG_FORMAT_MINOR_VERSION=$(echo "${CLANG_FORMAT_VERSION}" | sed 's/^[^0-9]*[0-9]*\.\([0-9]*\).*$/\1/g')
 
-if [ "${CLANG_FORMAT_MAJOR_VERSION}" -ne 8 ] || [ "${CLANG_FORMAT_MINOR_VERSION}" -ne 0 ]; then
-  echo "***   This indent script requires clang-format version 8.0,"
+if [ "${CLANG_FORMAT_MAJOR_VERSION}" -ne 16 ] || [ "${CLANG_FORMAT_MINOR_VERSION}" -ne 0 ]; then
+  echo "***   This indent script requires clang-format version 16.0,"
   echo "***   but version ${CLANG_FORMAT_MAJOR_VERSION}.${CLANG_FORMAT_MINOR_VERSION} was found instead."
   exit 1
 fi

--- a/scripts/docker/Dockerfile.clang
+++ b/scripts/docker/Dockerfile.clang
@@ -1,49 +1,13 @@
-ARG BASE=nvcr.io/nvidia/cuda:12.2.0-devel-ubuntu20.04
-FROM $BASE
+FROM ubuntu:24.04@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30
 
 RUN apt-get update && apt-get install -y \
         bc \
         git \
+        build-essential \
+        clang-format-16 \
         wget \
-        ccache \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN KEYDUMP_URL=https://cloud.cees.ornl.gov/download && \
-    KEYDUMP_FILE=keydump && \
-    wget --quiet ${KEYDUMP_URL}/${KEYDUMP_FILE} && \
-    wget --quiet ${KEYDUMP_URL}/${KEYDUMP_FILE}.sig && \
-    gpg --import ${KEYDUMP_FILE} && \
-    gpg --verify ${KEYDUMP_FILE}.sig ${KEYDUMP_FILE} && \
-    rm ${KEYDUMP_FILE}*
-
-ARG CMAKE_VERSION=3.16.8
-ENV CMAKE_DIR=/opt/cmake
-RUN CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION} && \
-    CMAKE_SCRIPT=cmake-${CMAKE_VERSION}-Linux-x86_64.sh && \
-    CMAKE_SHA256=cmake-${CMAKE_VERSION}-SHA-256.txt && \
-    wget --quiet ${CMAKE_URL}/${CMAKE_SHA256} && \
-    wget --quiet ${CMAKE_URL}/${CMAKE_SHA256}.asc && \
-    wget --quiet ${CMAKE_URL}/${CMAKE_SCRIPT} && \
-    gpg --verify ${CMAKE_SHA256}.asc ${CMAKE_SHA256} && \
-    grep -i ${CMAKE_SCRIPT} ${CMAKE_SHA256} | sed -e s/linux/Linux/ | sha256sum --check && \
-    mkdir -p ${CMAKE_DIR} && \
-    sh ${CMAKE_SCRIPT} --skip-license --prefix=${CMAKE_DIR} && \
-    rm cmake*
-ENV PATH=${CMAKE_DIR}/bin:$PATH
-
-ENV LLVM_DIR=/opt/llvm
-RUN LLVM_VERSION=8.0.0 && \
-    LLVM_URL=http://releases.llvm.org/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-16.04.tar.xz && \
-    LLVM_ARCHIVE=llvm-${LLVM_VERSION}.tar.xz && \
-    SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
-    wget --quiet ${LLVM_URL} --output-document=${LLVM_ARCHIVE} && \
-    wget --quiet ${LLVM_URL}.sig --output-document=${LLVM_ARCHIVE}.sig && \
-    gpg --verify ${LLVM_ARCHIVE}.sig ${LLVM_ARCHIVE} && \
-    mkdir -p ${LLVM_DIR} && \
-    tar -xvf ${LLVM_ARCHIVE} -C ${LLVM_DIR} --strip-components=1 && \
-    echo "${LLVM_DIR}/lib" > /etc/ld.so.conf.d/llvm.conf && ldconfig && \
-    rm -rf /root/.gnupg && \
-    rm -rf ${SCRATCH_DIR}
-ENV PATH=${LLVM_DIR}/bin:$PATH
+ENV CLANG_FORMAT_EXE=clang-format-16

--- a/scripts/docker/Dockerfile.openmpi
+++ b/scripts/docker/Dockerfile.openmpi
@@ -1,46 +1,45 @@
-FROM ubuntu:20.04                                                                                                                                                                                                                            
-                                                                                                                                                                                                                                             
-ENV DEBIAN_FRONTEND=noninteractive                                                                                                                                                                                                           
-RUN apt-get update && apt-get upgrade -y && apt-get install -y \                                                                                                                                                                             
-    build-essential \                                                                                                                                                                                                                        
-    wget \                                                                                                                                                                                                                                   
-    git \                                                                                                                                                                                                                                    
-    bc \                                                                                                                                                                                                                                     
-    ninja-build \                                                                                                                                                                                                                            
-    git \                                                                                                                                                                                                                                    
-    libev-dev \                                                                                                                                                                                                                              
-    libevent-dev \                                                                                                                                                                                                                           
-    libhwloc-dev \                                                                                                                                                                                                                           
-    pkg-config \                                                                                                                                                                                                                             
-    clang-format-8 \                                                                                                                                                                                                                         
-    && \                                                                                                                                                                                                                                     
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+    build-essential \
+    wget \
+    git \
+    bc \
+    ninja-build \
+    git \
+    libev-dev \
+    libevent-dev \
+    libhwloc-dev \
+    pkg-config \
+    && \
     apt-get clean && rm -rf /var/lib/apt/list
 
-ENV PREFIX=/scratch                                                                                                                                                                                                                          
-ENV ARCHIVE_DIR=${PREFIX}/archive                                                                                                                                                                                                            
-ENV SOURCE_DIR=${PREFIX}/source                                                                                                                                                                                                              
-ENV BUILD_DIR=${PREFIX}/build                                                                                                                                                                                                                
-ENV INSTALL_DIR=/opt                                                                                                                                                                                                                         
-                                                                                                                                                                                                                                             
-RUN mkdir -p ${PREFIX} && \                                                                                                                                                                                                                  
-    cd ${PREFIX} && \                                                                                                                                                                                                                        
-    mkdir archive && \                                                                                                                                                                                                                       
-    mkdir source && \                                                                                                                                                                                                                        
-    mkdir build                                                                                                                                                                                                                              
+ENV PREFIX=/scratch
+ENV ARCHIVE_DIR=${PREFIX}/archive
+ENV SOURCE_DIR=${PREFIX}/source
+ENV BUILD_DIR=${PREFIX}/build
+ENV INSTALL_DIR=/opt
+
+RUN mkdir -p ${PREFIX} && \
+    cd ${PREFIX} && \
+    mkdir archive && \
+    mkdir source && \
+    mkdir build
                                                                                                                                                                                                                                              
 # Install CMake                                                                                                                                                                                                                              
-RUN export CMAKE_VERSION=3.22.2 && \                                                                                                                                                                                                         
-    export CMAKE_SHA256=38b3befdee8fd2bac06954e2a77cb3072e6833c69d8cc013c0a3b26f1cfdfe37 && \                                                                                                                                                
-    export CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz && \                                                                                                    
-    export CMAKE_ARCHIVE=${ARCHIVE_DIR}/cmake.tar.gz && \                                                                                                                                                                                    
-    export CMAKE_BUILD_DIR=${BUILD_DIR}/cmake && \                                                                                                                                                                                           
-    wget --quiet ${CMAKE_URL} --output-document=${CMAKE_ARCHIVE} && \                                                                                                                                                                        
-    echo "${CMAKE_SHA256} ${CMAKE_ARCHIVE}" | sha256sum -c && \                                                                                                                                                                              
-    mkdir -p ${CMAKE_BUILD_DIR} && \                                                                                                                                                                                                         
-    tar xf ${CMAKE_ARCHIVE} -C ${CMAKE_BUILD_DIR} --strip-components=1 && \                                                                                                                                                                  
-    mv ${CMAKE_BUILD_DIR} ${INSTALL_DIR} && \                                                                                                                                                                                                
-    rm -rf ${CMAKE_ARCHIVE} && \                                                                                                                                                                                                             
-    rm -rf ${CMAKE_BUILD_DIR}                                                                                                                                                                                                                
+RUN export CMAKE_VERSION=3.22.2 && \
+    export CMAKE_SHA256=38b3befdee8fd2bac06954e2a77cb3072e6833c69d8cc013c0a3b26f1cfdfe37 && \
+    export CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz && \
+    export CMAKE_ARCHIVE=${ARCHIVE_DIR}/cmake.tar.gz && \
+    export CMAKE_BUILD_DIR=${BUILD_DIR}/cmake && \
+    wget --quiet ${CMAKE_URL} --output-document=${CMAKE_ARCHIVE} && \
+    echo "${CMAKE_SHA256} ${CMAKE_ARCHIVE}" | sha256sum -c && \
+    mkdir -p ${CMAKE_BUILD_DIR} && \
+    tar xf ${CMAKE_ARCHIVE} -C ${CMAKE_BUILD_DIR} --strip-components=1 && \
+    mv ${CMAKE_BUILD_DIR} ${INSTALL_DIR} && \
+    rm -rf ${CMAKE_ARCHIVE} && \
+    rm -rf ${CMAKE_BUILD_DIR}
 ENV PATH=${INSTALL_DIR}/cmake/bin:$PATH
 
 # Install UCX

--- a/src/core/Kokkos_RemoteSpaces_Error.hpp
+++ b/src/core/Kokkos_RemoteSpaces_Error.hpp
@@ -63,9 +63,9 @@ class RemoteSpacesMemoryAllocationFailure : public std::bad_alloc {
   RemoteSpacesMemoryAllocationFailure(
       RemoteSpacesMemoryAllocationFailure &&) noexcept = default;
 
-  RemoteSpacesMemoryAllocationFailure &operator             =(
+  RemoteSpacesMemoryAllocationFailure &operator=(
       RemoteSpacesMemoryAllocationFailure const &) noexcept = default;
-  RemoteSpacesMemoryAllocationFailure &operator             =(
+  RemoteSpacesMemoryAllocationFailure &operator=(
       RemoteSpacesMemoryAllocationFailure &&) noexcept = default;
 
   ~RemoteSpacesMemoryAllocationFailure() noexcept override = default;

--- a/src/core/Kokkos_RemoteSpaces_ViewLayout.hpp
+++ b/src/core/Kokkos_RemoteSpaces_ViewLayout.hpp
@@ -36,10 +36,10 @@ struct PartitionedLayoutLeft : public PartitionedLayout {
 
   enum : bool { is_extent_constructible = true };
 
-  PartitionedLayoutLeft(PartitionedLayoutLeft const &) = default;
-  PartitionedLayoutLeft(PartitionedLayoutLeft &&)      = default;
+  PartitionedLayoutLeft(PartitionedLayoutLeft const &)            = default;
+  PartitionedLayoutLeft(PartitionedLayoutLeft &&)                 = default;
   PartitionedLayoutLeft &operator=(PartitionedLayoutLeft const &) = default;
-  PartitionedLayoutLeft &operator=(PartitionedLayoutLeft &&) = default;
+  PartitionedLayoutLeft &operator=(PartitionedLayoutLeft &&)      = default;
 
   KOKKOS_INLINE_FUNCTION
   explicit constexpr PartitionedLayoutLeft(
@@ -62,10 +62,10 @@ struct PartitionedLayoutRight : public PartitionedLayout {
 
   enum : bool { is_extent_constructible = true };
 
-  PartitionedLayoutRight(PartitionedLayoutRight const &) = default;
-  PartitionedLayoutRight(PartitionedLayoutRight &&)      = default;
+  PartitionedLayoutRight(PartitionedLayoutRight const &)            = default;
+  PartitionedLayoutRight(PartitionedLayoutRight &&)                 = default;
   PartitionedLayoutRight &operator=(PartitionedLayoutRight const &) = default;
-  PartitionedLayoutRight &operator=(PartitionedLayoutRight &&) = default;
+  PartitionedLayoutRight &operator=(PartitionedLayoutRight &&)      = default;
 
   KOKKOS_INLINE_FUNCTION
   explicit constexpr PartitionedLayoutRight(
@@ -92,10 +92,10 @@ struct PartitionedLayoutStride : public PartitionedLayout {
 
   enum : bool { is_extent_constructible = false };
 
-  PartitionedLayoutStride(PartitionedLayoutStride const &) = default;
-  PartitionedLayoutStride(PartitionedLayoutStride &&)      = default;
+  PartitionedLayoutStride(PartitionedLayoutStride const &)            = default;
+  PartitionedLayoutStride(PartitionedLayoutStride &&)                 = default;
   PartitionedLayoutStride &operator=(PartitionedLayoutStride const &) = default;
-  PartitionedLayoutStride &operator=(PartitionedLayoutStride &&) = default;
+  PartitionedLayoutStride &operator=(PartitionedLayoutStride &&)      = default;
 
   /** \brief  Compute strides from ordered dimensions.
    *
@@ -139,8 +139,8 @@ struct PartitionedLayoutStride : public PartitionedLayout {
       size_t N5 = KOKKOS_IMPL_CTOR_DEFAULT_ARG, size_t S5 = 0,
       size_t N6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG, size_t S6 = 0,
       size_t N7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG, size_t S7 = 0)
-      : dimension{N0, N1, N2, N3, N4, N5, N6, N7}, stride{S0, S1, S2, S3,
-                                                          S4, S5, S6, S7} {}
+      : dimension{N0, N1, N2, N3, N4, N5, N6, N7},
+        stride{S0, S1, S2, S3, S4, S5, S6, S7} {}
 };
 
 namespace Impl {

--- a/src/core/Kokkos_RemoteSpaces_ViewOffset.hpp
+++ b/src/core/Kokkos_RemoteSpaces_ViewOffset.hpp
@@ -255,8 +255,8 @@ struct ViewOffset<
     return *this;
   }
 #else
-  ViewOffset()                   = default;
-  ViewOffset(const ViewOffset &) = default;
+  ViewOffset()                              = default;
+  ViewOffset(const ViewOffset &)            = default;
   ViewOffset &operator=(const ViewOffset &) = default;
 #endif
 
@@ -582,8 +582,8 @@ struct ViewOffset<
   }
 #else
 
-  ViewOffset()                   = default;
-  ViewOffset(const ViewOffset &) = default;
+  ViewOffset()                              = default;
+  ViewOffset(const ViewOffset &)            = default;
   ViewOffset &operator=(const ViewOffset &) = default;
 #endif
 
@@ -897,8 +897,8 @@ struct ViewOffset<
   }
 #else
 
-  ViewOffset()                   = default;
-  ViewOffset(const ViewOffset &) = default;
+  ViewOffset()                              = default;
+  ViewOffset(const ViewOffset &)            = default;
   ViewOffset &operator=(const ViewOffset &) = default;
 #endif
 
@@ -1224,8 +1224,8 @@ struct ViewOffset<
   }
 #else
 
-  ViewOffset()                   = default;
-  ViewOffset(const ViewOffset &) = default;
+  ViewOffset()                              = default;
+  ViewOffset(const ViewOffset &)            = default;
   ViewOffset &operator=(const ViewOffset &) = default;
 #endif
 
@@ -1572,8 +1572,8 @@ struct ViewOffset<Dimension, Kokkos::PartitionedLayoutStride, void> {
   }
 #else
 
-  ViewOffset()                   = default;
-  ViewOffset(const ViewOffset &) = default;
+  ViewOffset()                              = default;
+  ViewOffset(const ViewOffset &)            = default;
   ViewOffset &operator=(const ViewOffset &) = default;
 #endif
 

--- a/src/impl/mpispace/Kokkos_MPISpace.hpp
+++ b/src/impl/mpispace/Kokkos_MPISpace.hpp
@@ -55,9 +55,9 @@ class MPISpace {
   using size_type    = size_t;
 
   MPISpace();
-  MPISpace(MPISpace &&rhs)      = default;
-  MPISpace(const MPISpace &rhs) = default;
-  MPISpace &operator=(MPISpace &&) = default;
+  MPISpace(MPISpace &&rhs)              = default;
+  MPISpace(const MPISpace &rhs)         = default;
+  MPISpace &operator=(MPISpace &&)      = default;
   MPISpace &operator=(const MPISpace &) = default;
   ~MPISpace()                           = default;
 

--- a/src/impl/mpispace/Kokkos_MPISpace_AllocationRecord.hpp
+++ b/src/impl/mpispace/Kokkos_MPISpace_AllocationRecord.hpp
@@ -34,7 +34,7 @@ class SharedAllocationRecord<Kokkos::Experimental::MPISpace, void>
   using base_t = SharedAllocationRecordCommon<Kokkos::Experimental::MPISpace>;
   using RecordBase = SharedAllocationRecord<void, void>;
 
-  SharedAllocationRecord(const SharedAllocationRecord&) = delete;
+  SharedAllocationRecord(const SharedAllocationRecord&)            = delete;
   SharedAllocationRecord& operator=(const SharedAllocationRecord&) = delete;
 
 #ifdef KOKKOS_ENABLE_DEBUG

--- a/src/impl/nvshmemspace/Kokkos_NVSHMEMSpace.hpp
+++ b/src/impl/nvshmemspace/Kokkos_NVSHMEMSpace.hpp
@@ -47,9 +47,9 @@ class NVSHMEMSpace {
   using size_type    = size_t;
 
   NVSHMEMSpace();
-  NVSHMEMSpace(NVSHMEMSpace &&rhs)      = default;
-  NVSHMEMSpace(const NVSHMEMSpace &rhs) = default;
-  NVSHMEMSpace &operator=(NVSHMEMSpace &&) = default;
+  NVSHMEMSpace(NVSHMEMSpace &&rhs)              = default;
+  NVSHMEMSpace(const NVSHMEMSpace &rhs)         = default;
+  NVSHMEMSpace &operator=(NVSHMEMSpace &&)      = default;
   NVSHMEMSpace &operator=(const NVSHMEMSpace &) = default;
   ~NVSHMEMSpace()                               = default;
 

--- a/src/impl/nvshmemspace/Kokkos_NVSHMEMSpace_AllocationRecord.hpp
+++ b/src/impl/nvshmemspace/Kokkos_NVSHMEMSpace_AllocationRecord.hpp
@@ -32,7 +32,7 @@ class SharedAllocationRecord<Kokkos::Experimental::NVSHMEMSpace, void>
 
   typedef SharedAllocationRecord<void, void> RecordBase;
 
-  SharedAllocationRecord(const SharedAllocationRecord &) = delete;
+  SharedAllocationRecord(const SharedAllocationRecord &)            = delete;
   SharedAllocationRecord &operator=(const SharedAllocationRecord &) = delete;
 
   static void deallocate(RecordBase *);

--- a/src/impl/nvshmemspace/Kokkos_NVSHMEMSpace_BlockOps.hpp
+++ b/src/impl/nvshmemspace/Kokkos_NVSHMEMSpace_BlockOps.hpp
@@ -25,7 +25,7 @@
 namespace Kokkos {
 namespace Impl {
 
-//#define KRS_USES_NBI
+// #define KRS_USES_NBI
 
 #define KOKKOS_REMOTESPACES_PUT(type, op)                                 \
   static __device__ void shmem_block_type_put(type *dst, const type *src, \

--- a/src/impl/rocshmemspace/Kokkos_ROCSHMEMSpace.hpp
+++ b/src/impl/rocshmemspace/Kokkos_ROCSHMEMSpace.hpp
@@ -45,9 +45,9 @@ class ROCSHMEMSpace {
   using size_type    = size_t;
 
   ROCSHMEMSpace();
-  ROCSHMEMSpace(ROCSHMEMSpace &&rhs)      = default;
-  ROCSHMEMSpace(const ROCSHMEMSpace &rhs) = default;
-  ROCSHMEMSpace &operator=(ROCSHMEMSpace &&) = default;
+  ROCSHMEMSpace(ROCSHMEMSpace &&rhs)              = default;
+  ROCSHMEMSpace(const ROCSHMEMSpace &rhs)         = default;
+  ROCSHMEMSpace &operator=(ROCSHMEMSpace &&)      = default;
   ROCSHMEMSpace &operator=(const ROCSHMEMSpace &) = default;
   ~ROCSHMEMSpace()                                = default;
 

--- a/src/impl/rocshmemspace/Kokkos_ROCSHMEMSpace_AllocationRecord.hpp
+++ b/src/impl/rocshmemspace/Kokkos_ROCSHMEMSpace_AllocationRecord.hpp
@@ -32,7 +32,7 @@ class SharedAllocationRecord<Kokkos::Experimental::ROCSHMEMSpace, void>
 
   typedef SharedAllocationRecord<void, void> RecordBase;
 
-  SharedAllocationRecord(const SharedAllocationRecord &) = delete;
+  SharedAllocationRecord(const SharedAllocationRecord &)            = delete;
   SharedAllocationRecord &operator=(const SharedAllocationRecord &) = delete;
 
   static void deallocate(RecordBase *);

--- a/src/impl/shmemspace/Kokkos_SHMEMSpace.hpp
+++ b/src/impl/shmemspace/Kokkos_SHMEMSpace.hpp
@@ -55,9 +55,9 @@ class SHMEMSpace {
   using size_type    = size_t;
 
   SHMEMSpace();
-  SHMEMSpace(SHMEMSpace &&rhs)      = default;
-  SHMEMSpace(const SHMEMSpace &rhs) = default;
-  SHMEMSpace &operator=(SHMEMSpace &&) = default;
+  SHMEMSpace(SHMEMSpace &&rhs)              = default;
+  SHMEMSpace(const SHMEMSpace &rhs)         = default;
+  SHMEMSpace &operator=(SHMEMSpace &&)      = default;
   SHMEMSpace &operator=(const SHMEMSpace &) = default;
   ~SHMEMSpace()                             = default;
 

--- a/src/impl/shmemspace/Kokkos_SHMEMSpace_AllocationRecord.hpp
+++ b/src/impl/shmemspace/Kokkos_SHMEMSpace_AllocationRecord.hpp
@@ -34,7 +34,7 @@ class SharedAllocationRecord<Kokkos::Experimental::SHMEMSpace, void>
   using base_t = SharedAllocationRecordCommon<Kokkos::Experimental::SHMEMSpace>;
   using RecordBase = SharedAllocationRecord<void, void>;
 
-  SharedAllocationRecord(const SharedAllocationRecord&) = delete;
+  SharedAllocationRecord(const SharedAllocationRecord&)            = delete;
   SharedAllocationRecord& operator=(const SharedAllocationRecord&) = delete;
 
 #ifdef KOKKOS_ENABLE_DEBUG

--- a/unit_tests/Test_Subview.cpp
+++ b/unit_tests/Test_Subview.cpp
@@ -413,7 +413,7 @@ void test_partitioned_subview1D(int i1, int i2, int sub1, int sub2) {
   deep_copy(v_h, VAL);
 
   auto v_sub   = Kokkos::subview(v, std::make_pair(my_rank, my_rank + 1),
-                               Kokkos::ALL, Kokkos::ALL);
+                                 Kokkos::ALL, Kokkos::ALL);
   auto v_sub_1 = Kokkos::subview(v, Kokkos::ALL, sub1, sub2);
   auto v_sub_2 = ViewRemote_1D_t(v, Kokkos::ALL, sub1, sub2);
   Kokkos::deep_copy(v_sub, v_h);
@@ -454,7 +454,7 @@ void test_partitioned_subview2D(int i1, int i2, int sub1) {
   deep_copy(v_h, VAL);
 
   auto v_sub   = Kokkos::subview(v, std::make_pair(my_rank, my_rank + 1),
-                               Kokkos::ALL, Kokkos::ALL);
+                                 Kokkos::ALL, Kokkos::ALL);
   auto v_sub_1 = Kokkos::subview(v, Kokkos::ALL, sub1, Kokkos::ALL);
   auto v_sub_2 = ViewRemote_2D_t(v, Kokkos::ALL, sub1, Kokkos::ALL);
   Kokkos::deep_copy(v_sub, v_h);
@@ -571,7 +571,7 @@ void test_partitioned_subview2D_byRank_nextRank(int i1, int i2) {
   deep_copy(v_h, my_rank);
 
   auto v_sub      = Kokkos::subview(v, std::make_pair(my_rank, my_rank + 1),
-                               Kokkos::ALL, Kokkos::ALL);
+                                    Kokkos::ALL, Kokkos::ALL);
   auto v_sub_next = Kokkos::subview(v, next_rank, Kokkos::ALL, Kokkos::ALL);
   RemoteSpace_t::fence();
   Kokkos::deep_copy(v_sub, v_h);
@@ -610,7 +610,7 @@ void test_partitioned_subviewOfSubviewRange_2D(int i1, int i2) {
   deep_copy(v_h, my_rank);
 
   auto v_sub      = Kokkos::subview(v, std::make_pair(my_rank, my_rank + 1),
-                               Kokkos::ALL, Kokkos::ALL);
+                                    Kokkos::ALL, Kokkos::ALL);
   auto v_sub_next = Kokkos::subview(v, next_rank, Kokkos::ALL, Kokkos::ALL);
   auto v_sub_next_half = Kokkos::subview(
       v_sub_next, Kokkos::pair<int, int>(i1_half, i1), Kokkos::ALL);
@@ -653,7 +653,7 @@ void test_partitioned_subviewOfSubviewScalar_2D(int i1, int i2) {
   // Init
   deep_copy(v_h, my_rank);
   auto v_sub      = Kokkos::subview(v, std::make_pair(my_rank, my_rank + 1),
-                               Kokkos::ALL, Kokkos::ALL);
+                                    Kokkos::ALL, Kokkos::ALL);
   auto v_sub_next = Kokkos::subview(v, next_rank, Kokkos::ALL, Kokkos::ALL);
 
   // auto v_sub_next_1D = Kokkos::subview(v_sub_next, Kokkos::ALL, i1_half);


### PR DESCRIPTION
- Require clang-format16
- Updates Dockerfile.clang
- Updates Dockerfile.openmpi (Removes trailing whitespaces and removed clang-format from installation)